### PR TITLE
Re-introduce `appcall` variable in inner txn tests

### DIFF
--- a/api/handlers_e2e_test.go
+++ b/api/handlers_e2e_test.go
@@ -1275,6 +1275,8 @@ func TestLookupInnerLogs(t *testing.T) {
 	err = db.AddBlock(&blk)
 	require.NoError(t, err)
 
+	appCall, _, err := vb.Blk.BlockHeader.DecodeSignedTxn(blk.Block().Payset[0])
+
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			//////////
@@ -1304,7 +1306,7 @@ func TestLookupInnerLogs(t *testing.T) {
 			require.NotNil(t, response.LogData)
 			ld := *response.LogData
 			require.Equal(t, 1, len(ld))
-			// require.Equal(t, appCall.Txn.ID().String(), ld[0].Txid)
+			require.Equal(t, appCall.Txn.ID().String(), ld[0].Txid)
 			require.Equal(t, len(tc.logs), len(ld[0].Logs))
 			for i, log := range ld[0].Logs {
 				require.Equal(t, []byte(tc.logs[i]), log)
@@ -1374,6 +1376,8 @@ func TestLookupMultiInnerLogs(t *testing.T) {
 	err = db.AddBlock(&blk)
 	require.NoError(t, err)
 
+	appCall, _, err := vb.Blk.BlockHeader.DecodeSignedTxn(blk.Block().Payset[0])
+
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			//////////
@@ -1406,7 +1410,7 @@ func TestLookupMultiInnerLogs(t *testing.T) {
 
 			logCount := 0
 			for txnIndex, result := range ld {
-				// require.Equal(t, appCall.Txn.ID().String(), result.Txid)
+				require.Equal(t, appCall.Txn.ID().String(), result.Txid)
 				for logIndex, log := range result.Logs {
 					require.Equal(t, []byte(tc.logs[txnIndex*2+logIndex]), log)
 					logCount++


### PR DESCRIPTION

<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines
-->

## Summary

This PR re-introduces the appcall variable by reading from Block payset and re-enables txn ID checks in inner transactions.

## Test Plan

This is a test. Run CI tests to verify.